### PR TITLE
easier search and fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ optional arguments:
   -b BASEDIR, --base-dir BASEDIR
                         wordlists base directory [default: /usr/share/wordlists]
 
+  -f INDEX [INDEX ...], --fetch INDEX [INDEX ...]
+                        fetch the wordlists at the given indexes in the search results, see
+                        fetch options for additional options
+
+fetch options:
+  -d, --decompress      decompress and remove archive
+
+  -w WORKERS, --workers WORKERS
+                        download workers [default: 10]
+
+  -u USERAGENT, --useragent USERAGENT
+                        parser user agent [default: wordlistctl/v0.9.0]
 ```
 
 ### List Options
@@ -98,6 +110,18 @@ optional arguments:
                           fuzzing
                           misc
 
+  -f INDEX [INDEX ...], --fetch INDEX [INDEX ...]
+                        fetch the wordlists at the given indexes in the list, see
+                        fetch options for additional options
+
+fetch options:
+  -d, --decompress      decompress and remove archive
+
+  -w WORKERS, --workers WORKERS
+                        download workers [default: 10]
+
+  -u USERAGENT, --useragent USERAGENT
+                        parser user agent [default: wordlistctl/v0.9.0]
 ```
 
 ## Get Involved


### PR DESCRIPTION
I added a fetch flag to the search and list commands to fetch using an index from the results.
For exemple if we do `wordlistctl search wordlist`, the results would look like that:
```
   0 > wordlist1 (size)
   1 > wordlist2 (size)
   ...
```
and we can simply do `wordlistctl search wordlist -f 1` to download `wordlist2`. I reused the fetch parser and function so we can also add all the fetch arguments (eg. `wordlistctl search wordlist -f 1 -d -w 20`)

I don't know if it's a good idea but I was annoyed having to copy and paste the name everytime to fetch after a search.